### PR TITLE
新增一种 dismissal 转场，主要处理两种情况。

### DIFF
--- a/Demo/PhotoBrowser/MomentsViewController.swift
+++ b/Demo/PhotoBrowser/MomentsViewController.swift
@@ -63,7 +63,7 @@ class MomentsViewController: UIViewController {
         
         let lineSpacing: CGFloat = 10.0
         let height = itemSize * CGFloat(rowCount) + lineSpacing * 2
-        let y: CGFloat = 60.0
+        let y: CGFloat = 610.0
         
         let frame = CGRect(x: xMargin, y: y, width: width, height: height)
         
@@ -121,7 +121,7 @@ extension MomentsViewController: PhotoBrowserDelegate {
         return imageArray.count
     }
     
-    func photoBrowser(_ photoBrowser: PhotoBrowser, thumbnailViewForIndex index: Int) -> UIView {
+    func photoBrowser(_ photoBrowser: PhotoBrowser, thumbnailViewForIndex index: Int) -> UIView? {
         return collectionView!.cellForItem(at: IndexPath(item: index, section: 0))!
     }
     

--- a/PhotoBrowser/PhotoBrowser.swift
+++ b/PhotoBrowser/PhotoBrowser.swift
@@ -19,7 +19,7 @@ public protocol PhotoBrowserDelegate {
     
     /// 实现本方法以返回默认图所在view，在转场动画完成后将会修改这个view的hidden属性
     /// 比如你可返回ImageView，或整个Cell
-    func photoBrowser(_ photoBrowser: PhotoBrowser, thumbnailViewForIndex index: Int) -> UIView
+    func photoBrowser(_ photoBrowser: PhotoBrowser, thumbnailViewForIndex index: Int) -> UIView?
     
     /// 实现本方法以返回高质量图片。可选
     func photoBrowser(_ photoBrowser: PhotoBrowser, highQualityImageForIndex index: Int) -> UIImage?
@@ -94,7 +94,7 @@ public class PhotoBrowser: UIViewController {
     }
     
     /// 当前正在显示视图的前一个页面关联视图
-    fileprivate var relatedView: UIView {
+    fileprivate var relatedView: UIView? {
         return photoBrowserDelegate.photoBrowser(self, thumbnailViewForIndex: currentIndex)
     }
     

--- a/PhotoBrowser/ScaleAnimator.swift
+++ b/PhotoBrowser/ScaleAnimator.swift
@@ -54,22 +54,30 @@ public class ScaleAnimator: NSObject, UIViewControllerAnimatedTransitioning {
         
         // 求缩放视图的起始和结束frame
         guard let startView = self.startView,
-            let endView = self.endView,
             let scaleView = self.scaleView else {
             return
         }
-        guard let startFrame = startView.superview?.convert(startView.frame, to: containerView) else {
-            print("无法获取startFrame")
-            return
+        
+        let startFrame = startView.convert(startView.bounds, to: containerView)
+        var endFrame = startFrame
+        var endAlpha: CGFloat = 0.0
+        
+        if let endView = self.endView {
+            // 当前正在显示视图的前一个页面关联视图已经存在，此时分两种情况
+            // 1、该视图显示在屏幕内 2、该视图不显示在屏幕内
+            let relativeFrame = endView.convert(endView.bounds, to: nil)
+            let keyWindowBounds =  UIScreen.main.bounds
+            if keyWindowBounds.intersects(relativeFrame) { // 显示在屏幕内
+                endAlpha = 1.0
+                endFrame = endView.convert(endView.bounds, to: containerView)
+            }
         }
-        guard let endFrame = endView.superview?.convert(endView.frame, to: containerView) else {
-            print("无法获取endFrame")
-            return
-        }
+        
         scaleView.frame = startFrame
         containerView.addSubview(scaleView)
         
-        UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: { 
+        UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: {
+            scaleView.alpha = endAlpha
             scaleView.frame = endFrame
         }) { _ in
             // presentation转场，需要把目标视图添加到视图栈

--- a/PhotoBrowser/ScaleAnimatorCoordinator.swift
+++ b/PhotoBrowser/ScaleAnimatorCoordinator.swift
@@ -21,10 +21,10 @@ public class ScaleAnimatorCoordinator: UIPresentationController {
     }()
     
     /// 更新动画结束后需要隐藏的view
-    public func updateCurrentHiddenView(_ view: UIView) {
+    public func updateCurrentHiddenView(_ view: UIView?) {
         currentHiddenView?.isHidden = false
         currentHiddenView = view
-        view.isHidden = true
+        view?.isHidden = true
     }
     
     override public func presentationTransitionWillBegin() {


### PR DESCRIPTION
1、tableView 列表样式展示图片，当点击某一张浏览，然后左右滑动图片，此时其余 cell 并未被创建或者由于被重用导致当前浏览的图片的前一个页面关联视图不存在。
2、collectionView 展示图片，类似9宫格，但是只有最上面的三张图片显示在屏幕内，其余的6张均未显示在屏幕外，此时若采用缩放动画 dismiss，会出现，缩放视图 结束 frame 超出屏幕外的视觉效果，个人感觉不太好。

另外一个个人使用习惯
let startFrame = startView.superview?.convert(startView.frame, to: containerView)
let startFrame = startView.convert(startView.bounds, to: containerView)
这两行代码是等价的，下面一种写法感觉更简洁