### PR TITLE
修复locationInView返回nan导致crash的问题

### DIFF
--- a/PhotoBrowser/PhotoBrowserCell.swift
+++ b/PhotoBrowser/PhotoBrowserCell.swift
@@ -298,7 +298,7 @@ extension PhotoBrowserCell {
         let currentTouchDeltaY = yRate * height
         let y = currentTouch.y - currentTouchDeltaY
 
-        return (CGRect(x: x, y: y, width: width, height: height), scale)
+        return (CGRect(x: x.isNaN ? 0 : x, y: y.isNaN ? 0 : y, width: width, height: height), scale)
     }
 
     private func endPan() {


### PR DESCRIPTION
Terminating app due to uncaught exception 'CALayerInvalidGeometry', reason: 'CALayer position contains NaN: [nan nan]'