### PR TITLE
修改索引展示背景

### DIFF
--- a/Source/Core/Enhance/JXNumberPageControlDelegate.swift
+++ b/Source/Core/Enhance/JXNumberPageControlDelegate.swift
@@ -29,6 +29,10 @@ open class JXNumberPageControlDelegate: JXPhotoBrowserBaseDelegate {
         let view = UILabel()
         view.font = font
         view.textColor = textColor
+        view.textAlignment = NSTextAlignment.center
+        view.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.4)
+        view.layer.cornerRadius = 11
+        view.layer.masksToBounds = true
         return view
     }()
     
@@ -68,6 +72,7 @@ open class JXNumberPageControlDelegate: JXPhotoBrowserBaseDelegate {
         let totalPages = browser.itemsCount
         pageControl.text = "\(browser.pageIndex + 1) / \(totalPages)"
         pageControl.sizeToFit()
+        pageControl.frame.size.width = CGFloat((pageControl.text!.count-2) * 16)
         pageControl.center.x = superView.bounds.width / 2
         pageControl.frame.origin.y = offsetY
         pageControl.isHidden = totalPages <= 1


### PR DESCRIPTION
数字型页码指示器在白色背景下展示很模糊，展示的文字为白色，看不到页码指示器，添加一个圆角的背景，计算文字的宽度